### PR TITLE
Fixed docker image names

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Amazon Kinesis Streams enables you to build custom applications that process or 
  * [Kinesislite](https://github.com/mhart/kinesalite)
 
  ```bash
-docker run --rm -ti saidsef/aws-kinesis --help
+docker run --rm -ti saidsef/aws-kinesis-local --help
 
  Usage: kinesalite [--port <port>] [--path <path>] [--ssl] [options]
 
@@ -36,7 +36,7 @@ docker run --rm -ti saidsef/aws-kinesis --help
 ## Local Deployment
 
 ```bash
-docker run -d -p 4567:4567 saidsef/aws-kinesis --help
+docker run -d -p 4567:4567 saidsef/aws-kinesis-local --help
 ```
 
 ```bash


### PR DESCRIPTION
The docker image names in the documentation needed updating. I came across this issue trying to run the docker image locally. This change also matches the `Docker Pull Command` on https://hub.docker.com/r/saidsef/aws-kinesis-local