### PR TITLE
K8s health check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 dist: xenial
 sudo: required
+branches:
+  only:
+  - master
+  - "/^release-.*$/"
 before_install:
   - curl -fsSL https://get.docker.com | sh
   - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:13-alpine
 
 LABEL maintainer="Said Sef <saidsef@gmail.com> (saidsef.co.uk/)"
 LABEL "uk.co.saidsef.aws-kinesis"="Said Sef Associates Ltd"
-LABEL version="2.0"
+LABEL version="2.5"
 
 ARG PORT=""
 
@@ -11,9 +11,15 @@ ENV PORT ${PORT:-4567}
 
 WORKDIR /app
 
-RUN npm install -g kinesalite
+RUN npm install -g kinesalite@3.3.0 && \
+    mkdir -p /.npm /data && \
+    chown -R nobody:nobody /app /.npm /data
+
+USER nobody
 
 EXPOSE ${PORT}
+
+VOLUME ["/data"]
 
 HEALTHCHECK --interval=30s --timeout=10s CMD nc -zvw3 127.0.0.1 4567 || exit 1 
 

--- a/README.md
+++ b/README.md
@@ -63,3 +63,13 @@ aws --endpoint-url=http://svc-ip kinesis list-streams --region eu-west-1
 }
 
 ```
+
+```javascript
+// npm install aws-sdk
+const AWS = require('aws-sdk);
+
+let kinesis = new AWS.Kinesis({ endpoint: "http://svc-ip", region: "eu-west-1"})
+kinesis.listStreams(Console.log);
+```
+> The `endpoint` value depends on your deployment type
+> See [AWS documentations](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Kinesis.html)

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -28,6 +28,22 @@ spec:
             - protocol: TCP
               containerPort: 4567
               name: kinesis
+          livenessProbe:
+            exec:
+              command:
+                - pgrep
+                - node
+            initialDelaySeconds: 3
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 2
+          readinessProbe:
+            tcpSocket:
+                port: 4567
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
           volumeMounts:
             - name: kinesis-storage
               mountPath: /data


### PR DESCRIPTION
In this PR we've:
 - 5e0dcdd constraint ci to branches
 - 7152142 added JS implementation example
 - f38a171 isolate the container with user namespace nobody
 - a26cd3b added liveness and readness propes to k8s deployment