### PR TITLE
Bump node from 25.9-alpine to 26.2-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/node:25.9-alpine
+FROM docker.io/node:26.2-alpine
 
 LABEL org.opencontainers.image.authors="Said Sef <saidsef@gmail.com> (saidsef.co.uk/)"
 LABEL "uk.co.saidsef.aws-kinesis"="Said Sef Associates Ltd"


### PR DESCRIPTION
Bumps the base Docker image from node:25.9-alpine to node:26.2-alpine to keep up with the latest stable Node.js release.
