### PR TITLE
Improve helm test to validate Kinesis API with aws-cli

### DIFF
--- a/charts/kinesis/templates/tests/test-connection.yaml
+++ b/charts/kinesis/templates/tests/test-connection.yaml
@@ -8,8 +8,19 @@ metadata:
     "helm.sh/hook": test
 spec:
   containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "kinesis.fullname" . }}:{{ .Values.service.port }}']
+    - name: aws-cli
+      image: amazon/aws-cli:latest
+      command: ["aws"]
+      args:
+        - kinesis
+        - list-streams
+        - --endpoint-url
+        - "http://{{ include "kinesis.fullname" . }}:{{ .Values.service.port }}"
+        - --region
+        - "eu-west-1"
+      env:
+        - name: AWS_ACCESS_KEY_ID
+          value: "test"
+        - name: AWS_SECRET_ACCESS_KEY
+          value: "test"
   restartPolicy: Never


### PR DESCRIPTION

Replaces the shallow wget/busybox connection test with an actual aws kinesis list-streams call against the deployed service.
This validates that the Kinesis API is responding correctly, not just that the port is open.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Which issue/s this PR fixes:

fixes #40

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](../CONTRIBUTING.md) guide
- [X] I have added CI tests to cover my changes.
- [ ] All new and existing tests passed.
